### PR TITLE
fix: parse number as int instead of string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,10 @@ use rayon::prelude::*;
 // Need to run `forge build` before `cargo build`.
 abigen!(IERC1271, "./out/IERC1271.sol/IERC1271.json");
 
-fn to_signature(i: u64) -> Bytes {
-    let signature: Vec<u8> = format!("{}", i).as_bytes().into();
-    Bytes::from(signature)
+fn to_signature(i: u32) -> Bytes {
+    let mut hex = format!("{:x}", i);
+    if hex.len() % 2 == 1 {hex = format!("0{hex}");}
+    hex.parse().unwrap()
 }
 
 fn abi_encode(hash: [u8; 32], signature: Bytes) -> Vec<u8> {
@@ -29,7 +30,7 @@ fn main() {
             .try_into()
             .unwrap();
 
-    let res = (0..u64::MAX).into_par_iter().find_any(|i| {
+    let res = (0..u32::MAX).into_par_iter().find_any(|i| {
         let signature = to_signature(*i);
         let digest = digest_bytes(&abi_encode(hash, signature));
         // >>> cast sig "isValidSignature(bytes32,bytes)"


### PR DESCRIPTION
There's a solution within `u32` if you parse the numbers as ints instead of chars. Also speeds up the computation by 2x on my machine but not sure if that'll be consistent given the randomness in the search

```
i: 2364647611
signature: 0x8cf1a8bb
ABI encoding: "1626ba7e19bb34e293bba96bf0caeea54cdd3d2dad7fdf44cbea855173fa84534fcfb528000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000048cf1a8bb00000000000000000000000000000000000000000000000000000000"
sha256: 1626ba7e11c9fdc6c495f346beb65e2f712676389ec7733846f0457a36113dc1
```